### PR TITLE
Device restart API

### DIFF
--- a/lib/nacs-seq/manager.h
+++ b/lib/nacs-seq/manager.h
@@ -56,6 +56,8 @@ class Manager {
     struct DeviceInfo {
         std::string backend;
         YAML::Node config;
+        uint32_t n_restarts = 0;
+        bool marked; // flag for mark-and-sweep when updating config
     };
     struct LoggerRegister {
         LoggerRegister(Manager*);
@@ -177,6 +179,10 @@ public:
     {
         return m_engine;
     }
+
+    // Log device restart API
+    bool add_device_restart(const std::string &name, uint32_t n = 1);
+    uint32_t get_device_restart(const char *dname);
 
     // Error+warning API for python/matlab
     uint8_t *take_messages(size_t *sz);


### PR DESCRIPTION
Added some capabilities to support tracking device restart.

Of note:
1) New fields in DeviceInfo for tracking restarts and a flag for mark-and-sweep
2) Implementation of mark-and-sweep for update_config. Of note here is that I update all other fields except for the restart field.
3) Created one external C function for python to grab the device_restarts

Also not 100% sure if these should be private or not.