### PR TITLE
[seq/manager, seq/device] Add device restart on demand

### DIFF
--- a/lib/nacs-seq/device.h
+++ b/lib/nacs-seq/device.h
@@ -78,7 +78,10 @@ public:
     {
         return m_mgr;
     }
-
+    virtual uint32_t refresh_restart()
+    {
+        return 0;
+    }
 private:
 
     Manager &m_mgr;

--- a/lib/nacs-seq/manager.cpp
+++ b/lib/nacs-seq/manager.cpp
@@ -263,6 +263,16 @@ NACS_EXPORT() uint32_t Manager::ExpSeq::post_run()
     return id;
 }
 
+NACS_EXPORT() uint32_t Manager::ExpSeq::refresh_device_restart(const char *dname)
+{
+    auto it = m_devices.find(dname);
+    if (it != m_devices.end()) {
+        Device* dev = it->second.get();
+        return dev->refresh_restart();
+    }
+    return uint32_t(-1);
+}
+
 NACS_EXPORT_ Manager::Manager()
 {
 }
@@ -828,6 +838,13 @@ NACS_EXPORT() const uint8_t *nacs_seq_manager_expseq_get_seq_opt_dump(Manager::E
                                                                       size_t *sz)
 {
     return expseq->get_seq_opt_dump(sz);
+}
+
+NACS_EXPORT() uint32_t nacs_seq_manager_expseq_refresh_device_restart(Manager::ExpSeq *expseq, const char *dname)
+{
+    return expseq->mgr().call_guarded([&] {
+        return expseq->refresh_device_restart(dname);
+    }, uint32_t(-1));
 }
 
 }

--- a/lib/nacs-seq/manager.h
+++ b/lib/nacs-seq/manager.h
@@ -139,6 +139,8 @@ public:
         };
         std::unique_ptr<Dump> dump;
 
+        uint32_t refresh_device_restart(const char *dname);
+
     private:
         template<typename Str>
         Device *_get_device(Str &&name, bool create);


### PR DESCRIPTION
Added device restart tracking capability on demand, including a default refresh_restart function in device.h